### PR TITLE
Fixes `reply.redirect()` issue and updates to HAPI 6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
       var Hapi = plugin.hapi,
       response = request.response;
 
-      if (response.variety === 'plain' && typeof response.source.then === 'function') {
+      if (response.variety === 'plain' && !!response.source && typeof response.source.then === 'function') {
         return response.source.then(function (res) {
           response.source = res;
           return next(response);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-promise",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "A hapi plugin that allows you to return promises in your request handlers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
   },
   "homepage": "https://github.com/valet-io/hapi-promise",
   "devDependencies": {
-    "hapi": "~2.1.2",
-    "lab": "~1.5.0",
-    "bluebird": "~1.0.1"
+    "bluebird": "^2.3.2",
+    "lab": "^4.2.0"
   },
   "peerDependencies": {
-    "hapi": "2.x"
+    "hapi": "^6.7.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -56,6 +56,21 @@ describe('Hapi Promise', function () {
     });
   });
 
+  it('replies with a redirect', function (done) {
+    server.route({
+      method: 'GET',
+      path: '/redirect',
+      handler: function (request, reply) {
+        reply.redirect('/foo');
+      }
+    });
+
+    server.inject('/redirect', function (response) {
+      expect(response.statusCode).to.equal(302);
+      done();
+    });
+  });
+
   it('replies with a Hapi.error rejection', function (done) {
     server.route({
       method: 'GET',

--- a/test.js
+++ b/test.js
@@ -1,9 +1,10 @@
 var Lab         = require('lab'),
-    describe    = Lab.experiment,
-    it          = Lab.test,
+    lab         = module.exports.lab = Lab.script(),
+    describe    = lab.experiment,
+    it          = lab.test,
     expect      = Lab.expect,
-    before      = Lab.before,
-    after       = Lab.after;
+    before      = lab.before,
+    after       = lab.after;
 
 var Promise     = require('bluebird');
 
@@ -86,6 +87,7 @@ describe('Hapi Promise', function () {
       done();
     });
   });
+
   it('casts any other rejection into a Hapi.error.internal', function (done) {
     server.route({
       method: 'GET',


### PR DESCRIPTION
`reply.redirect()` doesn't set `response.source` it seems. This patch fixes that and updates to latest HAPI.
