### PR TITLE
support response schema validation after promise resolves

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 exports.register = function (plugin, options, next) {
 
-  plugin.ext('onPreResponse', function (request, reply) {
+  plugin.ext('onPostHandler', function (request, reply) {
     var res = request.response;
     if (res.source && typeof res.source.then === 'function') {
       return res.source
@@ -21,4 +21,4 @@ exports.register = function (plugin, options, next) {
 
 exports.register.attributes = {
   pkg: require('./package.json')
-}
+};

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   },
   "homepage": "https://github.com/bendrucker/hapi-as-promised",
   "devDependencies": {
+    "bluebird": "2",
     "hapi": "7",
-    "lab": "4",
-    "bluebird": "2"
+    "joi": "4",
+    "lab": "4"
   },
   "peerDependencies": {
     "hapi": "6 || 7"

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ var before   = lab.before;
 var expect   = Lab.expect;
 var Promise  = require('bluebird');
 var hapi     = require('hapi');
+var joi      = require('joi');
 
 
 describe('hapi-as-promised', function () {
@@ -83,6 +84,27 @@ describe('hapi-as-promised', function () {
     server.inject('/error', function (response) {
       expect(response.statusCode).to.equal(403);
       expect(response.result).to.have.property('error', err.message);
+      done();
+    });
+  });
+
+  it('handles promises with response validation', function (done) {
+    server.route({
+      method: 'GET',
+      path: '/validate',
+      handler: function (request, reply) {
+        reply(Promise.resolve({ key: 'value' })).code(201);
+      },
+      config: {
+        response: {
+          schema: joi.object().keys({ key: joi.string() })
+        }
+      }
+    });
+
+    server.inject('/validate', function (response) {
+      expect(response.result).to.deep.equal({ key: 'value' });
+      expect(response.statusCode).to.equal(201);
       done();
     });
   });


### PR DESCRIPTION
Response schema validation happens after `onPostHandler` and before `onPreResponse`.  If you want to use response schema validation with hapi-as-promised, everything currently explodes.  This change (with test included) allows the promise to resolve before checking against validation.
